### PR TITLE
Use toplevel window address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,6 @@ dependencies = [
  "image",
  "log",
  "memfd",
- "regex",
  "thiserror 2.0.11",
  "wayland-backend",
  "wayland-client",

--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -31,15 +31,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "aligned-vec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,7 +454,6 @@ dependencies = [
  "image",
  "log",
  "memfd",
- "regex",
  "thiserror 2.0.11",
  "wayland-backend",
  "wayland-client",
@@ -985,35 +975,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rgb"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,7 +13,6 @@ wayland-client = "0.31.8"
 wayland-protocols-wlr = { version = "0.3.6", features = ["client"] }
 wayland-scanner = "0.31.6"
 hyprland = { version = "0.4.0-beta.1", optional = true }
-regex = "1.11.1"
 thiserror = "2.0.11"
 
 [features]

--- a/lib/src/toplevel.rs
+++ b/lib/src/toplevel.rs
@@ -1,5 +1,3 @@
-use regex::Regex;
-
 #[derive(Clone, Debug)]
 pub struct Toplevel {
     /// id of the wayland toplevel
@@ -8,6 +6,8 @@ pub struct Toplevel {
     pub class: String,
     /// title of the hyprland window the toplevel belongs to
     pub title: String,
+    /// address of the window associated with the toplevel
+    pub window_address: u64,
 }
 
 impl Toplevel {
@@ -15,22 +15,41 @@ impl Toplevel {
     /// which is set by the hyprland desktop portal
     ///
     /// see: https://github.com/hyprwm/xdg-desktop-portal-hyprland/blob/e09dfe2726c8008f983e45a0aa1a3b7416aaeb8a/src/shared/ScreencopyShared.cpp#L61
-    pub fn parse(toplevel_list: &str) -> Vec<Toplevel> {
-        let regex = Regex::new(r"\[HC>\]|\[HT>\]").expect("should be valid regex");
+    pub fn parse_list(toplevel_list: &str) -> Vec<Toplevel> {
+        let mut toplevels = Vec::new();
 
-        let toplevels = toplevel_list
-            .split("[HE>]")
-            .filter_map(|part| {
-                let split = regex.split(part).collect::<Vec<_>>();
-                if split.len() != 3 {
-                    return None;
-                }
-                let id = split[0].parse::<u64>().ok()?;
-                let class = split[1].to_string();
-                let title = split[2].to_string();
-                Some(Toplevel { id, class, title })
-            })
-            .collect::<Vec<_>>();
+        let mut str = toplevel_list;
+        while !str.is_empty() {
+            let Some(id_sep_pos) = str.find("[HC>]") else {
+                log::warn!("found no toplevel id separator");
+                break;
+            };
+            let Ok(id) = str[0..id_sep_pos].parse::<u64>() else {
+                log::warn!("toplevel id cannot be parsed to unsigned integer");
+                break;
+            };
+            let Some(class_sep_pos) = str.find("[HT>]") else {
+                log::warn!("found no toplevel class separator");
+                break;
+            };
+            let class = str[id_sep_pos+5..class_sep_pos].to_string();
+            let Some(title_sep_pos) = str.find("[HE>]") else {
+                log::warn!("found no toplevel title separator");
+                break;
+            };
+            let title = str[class_sep_pos+5..title_sep_pos].to_string();
+            let Some(window_sep_pos) = str.find("[HA>]") else {
+                log::warn!("found no toplevel window separator");
+                break;
+            };
+            let Ok(window_address) = str[title_sep_pos+5..window_sep_pos].parse::<u64>() else {
+                log::warn!("window address cannot be parsed to unsigned integer");
+                break;
+            };
+
+            toplevels.push(Toplevel { id, class, title, window_address });
+            str = &str[window_sep_pos+5..]
+        }
 
         return toplevels;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -253,7 +253,7 @@ pub struct WindowsConfig {
 
 impl Default for WindowsConfig {
     fn default() -> Self {
-        Self { min_per_row: 3, max_per_row: 999, clicks: 2, spacing: 12 }
+        Self { min_per_row: 3, max_per_row: 4, clicks: 2, spacing: 12 }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None => {
             let toplevel_sharing_list = std::env::var("XDPH_WINDOW_SHARING_LIST").unwrap_or_default();
             log::debug!("XDPH_WINDOW_SHARING_LIST = {toplevel_sharing_list}");
-            let toplevels = Toplevel::parse(&toplevel_sharing_list);
+            let toplevels = Toplevel::parse_list(&toplevel_sharing_list);
             log::debug!("using config: {config:#?}");
 
             log::debug!("got toplevels {toplevels:#?}");

--- a/src/views/windows.rs
+++ b/src/views/windows.rs
@@ -70,7 +70,7 @@ impl View for WindowsView<'_> {
                 None => return log::error!("unable to find hyprland monitor for hyprland client"),
             };
 
-            let window_card = WindowCard::new(toplevel, client, self.config, monitor.transform, self.manager.clone());
+            let window_card = WindowCard::new(toplevel, self.config, monitor.transform, self.manager.clone());
             let card = match window_card.build() {
                 Ok(card) => card,
                 Err(err) => return log::error!("unable to build window card for toplevel {}: {err}", toplevel.id),
@@ -89,15 +89,14 @@ impl View for WindowsView<'_> {
 
 struct WindowCard<'a> {
     toplevel: &'a Toplevel,
-    client: &'a Client,
     config: &'a Config,
     manager: Arc<FrameManager>,
     transform: Transforms,
 }
 
 impl<'a> WindowCard<'a> {
-    pub fn new(toplevel: &'a Toplevel, client: &'a Client, config: &'a Config, transform: Transforms, manager: Arc<FrameManager>) -> Self {
-        WindowCard { toplevel, client, config, manager, transform }
+    pub fn new(toplevel: &'a Toplevel, config: &'a Config, transform: Transforms, manager: Arc<FrameManager>) -> Self {
+        WindowCard { toplevel, config, manager, transform }
     }
 
     pub fn build(self) -> Result<FlowBoxChild, String> {
@@ -171,8 +170,7 @@ impl<'a> WindowCard<'a> {
     }
 
     fn request_frame(&self, tx: Sender<Image>) {
-        let handle_str = &format!("{}", self.client.address)[2..];
-        let handle = u64::from_str_radix(handle_str, 16).expect("should be valid u64");
+        let handle = self.toplevel.window_address;
         let id = self.toplevel.id;
         let resize_size = self.config.image.resize_size;
         let manager = self.manager.clone();


### PR DESCRIPTION
Adjust the toplevel parser to use the new `[HA>]` field which contains the address of the window associated with the toplevel. This way it's possible to uniquely identify a toplevel and therefore we no longer have the same preview picture for toplevels with identical class + title

> The pull request can be merged as soon as the `hyprland-toplevel-mapping-v1` protocol is merged into hyprland

close #2 