### PR TITLE
Sanitize window title and class

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use hyprland::data::Monitor;
+use hyprland::data::{Client, Monitor};
 
 pub trait MonitorTransformExt {
     fn apply_transform(&mut self);
@@ -19,4 +19,19 @@ impl MonitorTransformExt for Monitor {
             }
         }
     }
+}
+
+pub trait ClientExt {
+    fn sanitize(&mut self);
+}
+
+impl ClientExt for Client {
+    fn sanitize(&mut self) {
+        self.title = sanitize_string(&self.title);
+        self.class = sanitize_string(&self.class);
+    }
+}
+
+fn sanitize_string(target: &str) -> String {
+    target.replace(['\'', '\"', '$', '`'], " ").replace(">]", ">")
 }

--- a/src/views/outputs.rs
+++ b/src/views/outputs.rs
@@ -78,7 +78,7 @@ impl<'a> OutputsView<'a> {
             translations.insert(m.id, 0);
         });
 
-        self.monitors.sort_by(|a, b| a.x.cmp(&b.x));
+        self.monitors.sort_by_key(|a| a.x);
         let copy = self.monitors.clone();
         self.monitors.iter_mut().for_each(|m| {
             translations.insert(m.id, 0);
@@ -101,7 +101,7 @@ impl<'a> OutputsView<'a> {
             *value = 0;
         });
 
-        self.monitors.sort_by(|a, b| a.y.cmp(&b.y));
+        self.monitors.sort_by_key(|a| a.y);
         let copy = self.monitors.clone();
         self.monitors.iter_mut().for_each(|m| {
             if m.scale != 1.0 {
@@ -246,12 +246,12 @@ impl<'a> OutputCard<'a> {
             #[strong]
             name,
             move |gesture, n, _, _| {
-                if n as i64 == clicks as i64 {
-                    if let Some(widget) = gesture.widget() {
-                        widget
-                            .activate_action("win.select", Some(&format!("screen:{name}").to_variant()))
-                            .expect("select action should be registered on the window")
-                    }
+                if n as i64 == clicks as i64
+                    && let Some(widget) = gesture.widget()
+                {
+                    widget
+                        .activate_action("win.select", Some(&format!("screen:{name}").to_variant()))
+                        .expect("select action should be registered on the window")
                 }
             }
         ));

--- a/src/views/windows.rs
+++ b/src/views/windows.rs
@@ -13,7 +13,7 @@ use hyprland_preview_share_picker_lib::{frame::FrameManager, image::Image, tople
 use tokio::sync::oneshot::{Receiver, Sender};
 use wayland_client::Connection;
 
-use crate::{config::Config, image::ImageExt};
+use crate::{config::Config, image::ImageExt, util::ClientExt};
 
 use super::View;
 
@@ -31,7 +31,15 @@ impl<'a> WindowsView<'a> {
             .map(Arc::new)
             .map_err(|err| format!("unable to create new frame manager from connection: {err}"))?;
         let clients = Clients::get()
-            .map(|clients| clients.into_iter().collect::<Vec<_>>())
+            .map(|clients| {
+                clients
+                    .into_iter()
+                    .map(|mut client| {
+                        client.sanitize();
+                        client
+                    })
+                    .collect::<Vec<_>>()
+            })
             .map_err(|err| format!("unable to get clients from hyprland socket: {err}"))?;
         let monitors = Monitors::get()
             .map(|monitors| monitors.into_iter().collect::<Vec<_>>())
@@ -72,7 +80,7 @@ impl View for WindowsView<'_> {
             let handle_str = &format!("{}", client.address)[2..];
             let handle = match u64::from_str_radix(handle_str, 16) {
                 Ok(handle) => handle,
-                Err(err) => return log::error!("unable to convert client address to u64: {err}")
+                Err(err) => return log::error!("unable to convert client address to u64: {err}"),
             };
 
             let window_card = WindowCard::new(toplevel, self.config, monitor.transform, handle, self.manager.clone());
@@ -101,11 +109,17 @@ struct WindowCard<'a> {
     config: &'a Config,
     manager: Arc<FrameManager>,
     transform: Transforms,
-    alt_handle: u64
+    alt_handle: u64,
 }
 
 impl<'a> WindowCard<'a> {
-    pub fn new(toplevel: &'a Toplevel, config: &'a Config, transform: Transforms, alt_handle: u64, manager: Arc<FrameManager>) -> Self {
+    pub fn new(
+        toplevel: &'a Toplevel,
+        config: &'a Config,
+        transform: Transforms,
+        alt_handle: u64,
+        manager: Arc<FrameManager>,
+    ) -> Self {
         WindowCard { alt_handle, toplevel, config, manager, transform }
     }
 
@@ -162,12 +176,12 @@ impl<'a> WindowCard<'a> {
         let clicks = self.config.windows.clicks;
         let id = self.toplevel.id;
         gesture.connect_released(move |gesture, n, _, _| {
-            if n as i64 == clicks as i64 {
-                if let Some(widget) = gesture.widget() {
-                    widget
-                        .activate_action("win.select", Some(&format!("window:{id}").to_variant()))
-                        .expect("select action should be registered on the window")
-                }
+            if n as i64 == clicks as i64
+                && let Some(widget) = gesture.widget()
+            {
+                widget
+                    .activate_action("win.select", Some(&format!("window:{id}").to_variant()))
+                    .expect("select action should be registered on the window")
             }
         });
         container.add_controller(gesture);
@@ -181,7 +195,10 @@ impl<'a> WindowCard<'a> {
 
     fn request_frame(&self, tx: Sender<Image>) {
         let handle = self.toplevel.window_address.unwrap_or_else(|| {
-            log::warn!("missing window address in toplevel {}: falling back to potentially non unique socket window address", self.toplevel.id);
+            log::warn!(
+                "missing window address in toplevel {}: falling back to potentially non unique socket window address",
+                self.toplevel.id
+            );
             self.alt_handle
         });
         let id = self.toplevel.id;


### PR DESCRIPTION
As #11 mentioned, xdph replaces some characters of window titles and classes with whitespaces. This pull request now implements the same sanitation for the clients returned from 'hyprland-rs`

Fixes #11