### PR TITLE
Ignore disabled monitors

### DIFF
--- a/src/views/outputs.rs
+++ b/src/views/outputs.rs
@@ -57,7 +57,7 @@ impl<'a> OutputsView<'a> {
             .map(Arc::new)
             .map_err(|err| format!("unable to create new output manager from connection: {err}"))?;
         let mut monitors = Monitors::get()
-            .map(|monitors| monitors.into_iter().collect::<Vec<_>>())
+            .map(|monitors| monitors.into_iter().filter(|monitor| !monitor.disabled).collect::<Vec<_>>())
             .map_err(|err| format!("unable to get monitors from hyprland socket: {err}"))?;
 
         // apply the transformations (rotations) to all monitors


### PR DESCRIPTION
Turns out hyprland-rs uses the `monitors all` dispatcher instead of only `monitors`. This also returns disabled monitors but we're not interested in them.

This pull request fixes #18 by just ignoring those disabled monitors.